### PR TITLE
feat: unsplit wrapException with improved types & runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ import { wrapException } from 'ts-to-go';
 
 // An async function
 const asyncFn = async (param: string) => {
-if (param === 'error') throw new Error('Oops! An error occurred.');
+  if (param === 'error') throw new Error('Oops! An error occurred.');
 
-return 'Success';
+  return 'Success';
 };
 
 // Wrap it using wrapException
@@ -40,20 +40,20 @@ console.log(error, result); // Error: 'Oops! An error occurred.' Result: undefin
 
 ### 2. Wrapping Synchronous Functions
 
-You can wrap synchronous functions using `wrapExceptionSync` in a similar way. It returns an array with either `[undefined, Result]` when the function execution is successful or `[Error, undefined]` when an error is thrown.
+You can wrap synchronous functions using `wrapException` in a similar way. It returns an array with either `[undefined, Result]` when the function execution is successful or `[Error, undefined]` when an error is thrown.
 
 ```ts
-import { wrapExceptionSync } from 'ts-to-go';
+import { wrapException } from 'ts-to-go';
 
 // A sync function
 const syncFn = (num1: number, num2: number) => {
-if (num1 === 0) throw new Error('Zero is not allowed.');
+  if (num1 === 0) throw new Error('Zero is not allowed.');
 
-return num1 + num2;
+  return num1 + num2;
 };
 
-// Wrap it using wrapExceptionSync
-const wrappedSyncFn = wrapExceptionSync(syncFn);
+// Wrap it using wrapException
+const wrappedSyncFn = wrapException(syncFn);
 
 // Use the wrapped function
 const [error, result] = wrappedSyncFn(0, 1);

--- a/src/wrapException/index.test.ts
+++ b/src/wrapException/index.test.ts
@@ -1,4 +1,4 @@
-import { wrapException, wrapExceptionSync } from './index';
+import { wrapException } from './index';
 
 describe('wrapException - async', () => {
   describe('async/await', () => {
@@ -75,6 +75,21 @@ describe('wrapException - async', () => {
       expect(error).toBeInstanceOf(Error);
       expect(error).toHaveProperty('message', 'test error');
     });
+
+    it('should return the error in a tuple with 2 positions when the promise throws', async () => {
+      const wrappedFn = wrapException(
+        async () =>
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          new Promise((_resolve, _reject) => {
+            // something weird happened
+            throw new Error('test error from throw');
+          }),
+      );
+
+      const [error] = await wrappedFn();
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toHaveProperty('message', 'test error from throw');
+    });
   });
 
   describe('invalid async function', () => {
@@ -93,14 +108,14 @@ describe('wrapException - async', () => {
 
 describe('wrapException - sync', () => {
   it('should return the result in a tuple with 2 positions when the function executes', () => {
-    const wrappedFn = wrapExceptionSync(() => 'test');
+    const wrappedFn = wrapException(() => 'test');
     const result = wrappedFn();
 
     expect(result).toEqual([undefined, 'test']);
   });
 
   it('should return the error in a tuple with 2 positions when the function throws', () => {
-    const wrappedFn = wrapExceptionSync((num1: number) => {
+    const wrappedFn = wrapException((num1: number) => {
       if (num1 === 0) throw new Error('test error');
     });
 

--- a/src/wrapException/index.ts
+++ b/src/wrapException/index.ts
@@ -1,3 +1,5 @@
+import util from 'node:util';
+
 export type AsyncFn<Args extends unknown[], Result = unknown> = (
   ...args: Args
 ) => Promise<Result>;
@@ -10,11 +12,44 @@ export type WrappedResponse<Result = unknown> =
   | readonly [undefined, Result]
   | readonly [unknown, undefined];
 
+const isPromise = <Args extends unknown[], Result = unknown>(
+  value:
+    | AsyncFn<Args, Result>
+    | SyncFn<Args, Result>
+    | SyncFn<Args, PromiseLike<Result>>
+    | Result
+    | PromiseLike<Result>,
+): value is AsyncFn<Args, Result> => {
+  return (
+    (value != null &&
+      (typeof value === 'object' || typeof value === 'function') &&
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+      typeof (value as any).then === 'function') ||
+    util.types.isAsyncFunction(value) ||
+    util.types.isPromise(value)
+  );
+};
+
+// async
+export function wrapException<Args extends unknown[], Response>(
+  fn: AsyncFn<Args, Response>,
+): (...args: Args) => Promise<WrappedResponse<Response>>;
+
+// fully sync
+export function wrapException<Args extends unknown[], Response>(
+  fn: SyncFn<Args, Response>,
+): (...args: Args) => WrappedResponse<Response>;
+
+// sync with promise on return
+export function wrapException<Args extends unknown[], Response>(
+  fn: SyncFn<Args, PromiseLike<Response>>,
+): (...args: Args) => Promise<WrappedResponse<Response>>;
+
 /**
- * Wraps an ASYNC function
+ * Wraps either async and sync functions
  * Returns a comprehensible tuple interface for better error handling
  * @returns [Error, Result]
- * @example
+ * @example async
   const wrappedFn = wrapException(async (param1: string) => {
     if (param1 === 'bar') throw new Error('bar');
 
@@ -29,32 +64,7 @@ export type WrappedResponse<Result = unknown> =
   // result: string | undefined
 
   console.log('bar', error, result); // bar bar undefined
-  */
-export function wrapException<Args extends unknown[], Response>(
-  fn: AsyncFn<Args, Response>,
-): (...args: Args) => Promise<WrappedResponse<Response>> {
-  // Handles async functions
-  return async (...args: Args): Promise<WrappedResponse<Response>> => {
-    try {
-      // Cast FN to Promise
-      const result = await Promise.resolve(fn(...args))
-        .then((r) => [undefined, r] as const)
-        // Catches rejects from Promises & throws from AsyncFunctions - avoids "Unhandled promise rejection"
-        .catch((error: unknown) => [error, undefined] as const);
-
-      return result;
-    } catch (error: unknown) {
-      // Catches errors from the above execution
-      return [error, undefined] as const;
-    }
-  };
-}
-
-/**
- * Wraps a SYNC function
- * Returns a comprehensible tuple interface for better error handling
- * @returns [Error, Result]
- * @example
+ * @example sync
   const wrappedFn = wrapException((param1: string) => {
     if (param1 === 'bar') throw new Error('bar');
 
@@ -69,14 +79,68 @@ export function wrapException<Args extends unknown[], Response>(
   // result: string | undefined
 
   console.log('bar', error, result); // bar bar undefined
+ * @example "sync" but returning promise
+  const wrappedFn = wrapException((param1: string) => {
+    if (param1 === 'bar') return Promise.reject(new Error('bar'));
+
+    return 'foo';
+  });
+
+  // wrappedFn will be typed with `const wrappedFn: (param1: string) => Promise<WrappedResponse<string>>`
+
+  const [error, result] = wrappedFn('bar');
+
+  // error: unknown
+  // result: string | undefined
+
+  console.log('bar', error, result); // bar bar undefined
   */
-export function wrapExceptionSync<Args extends unknown[], Response>(
-  fn: SyncFn<Args, Response>,
-): (...args: Args) => WrappedResponse<Response> {
-  return (...args: Args): WrappedResponse<Response> => {
+export function wrapException<Args extends unknown[], Response>(
+  fn:
+    | AsyncFn<Args, Response>
+    | SyncFn<Args, Response>
+    | SyncFn<Args, PromiseLike<Response>>,
+): (
+  ...args: Args
+) => Promise<WrappedResponse<Response>> | WrappedResponse<Response> {
+  const handlePromise =
+    (fnExec: AsyncFn<Args, Response>) =>
+    async (...args: Args): Promise<WrappedResponse<Response>> => {
+      try {
+        // Cast FN to Promise
+        const result = await Promise.resolve(
+          typeof fnExec === 'function' ? fnExec(...args) : fnExec,
+        )
+          .then((r) => [undefined, r] as const)
+          // Catches rejects from Promises & throws from AsyncFunctions - avoids "Unhandled promise rejection"
+          .catch((error: unknown) => [error, undefined] as const);
+
+        return result;
+      } catch (error: unknown) {
+        // Catches errors from the above execution
+        return [error, undefined] as const;
+      }
+    };
+
+  if (isPromise(fn)) {
+    // Handles async functions
+    return handlePromise(fn);
+  }
+
+  // Handles sync functions
+  return (
+    ...args: Args
+  ): WrappedResponse<Response> | Promise<WrappedResponse<Response>> => {
     // Handles sync functions
     try {
-      const result = fn(...args);
+      const possiblePromise = fn(...args);
+
+      // Handles unknown functions
+      if (isPromise(possiblePromise)) {
+        return handlePromise(possiblePromise)(...args);
+      }
+
+      const result = possiblePromise as Response;
 
       return [undefined, result] as const;
     } catch (error: unknown) {


### PR DESCRIPTION
Proposal: have only one exported member for wrapException.
Pros: only one function to care about for consumers
Downsides: as there are "unlimited crazy" ways for making promises run, our type guard might not be very safe and accurate. Which might cause issues during runtime (e.g. unhandled promises, etc)